### PR TITLE
Change Prints from ImportError to raised ImportWarning

### DIFF
--- a/trixi/experiment/__init__.py
+++ b/trixi/experiment/__init__.py
@@ -3,5 +3,6 @@ from trixi.experiment.experiment import Experiment
 try:
     from trixi.experiment.pytorchexperiment import PytorchExperiment
 except ImportError as e:
-    print("Could not import Pytorch related modules.")
-    print(e)
+    import warnings
+    warnings.warn(ImportWarning("Could not import Pytorch related modules:\n%s"
+        % e.msg))

--- a/trixi/logger/__init__.py
+++ b/trixi/logger/__init__.py
@@ -11,11 +11,13 @@ try:
     from trixi.logger.file.pytorchplotfilelogger import PytorchPlotFileLogger
     from trixi.logger.visdom.pytorchvisdomlogger import PytorchVisdomLogger
 except ImportError as e:
-    print("Could not import Pytorch related modules.")
-    print(e)
+    import warnings
+    warnings.warn(ImportWarning("Could not import Pytorch related modules:\n%s"
+        % e.msg))
 
 try:
     from trixi.logger.message.telegrammessagelogger import TelegramMessageLogger
 except ImportError as e:
-    print("Could not import Telegram related modules.")
-    print(e)
+    import warnings
+    warnings.warn(ImportWarning("Could not import Telegram related modules:\n%s"
+        % e.msg))

--- a/trixi/util/util.py
+++ b/trixi/util/util.py
@@ -25,8 +25,9 @@ from scipy.misc import imsave
 try:
     import torch
 except ImportError as e:
-    print("Could not import Pytorch related modules.")
-    print(e)
+    import warnings
+    warnings.warn(ImportWarning("Could not import Pytorch related modules:\n%s"
+        % e.msg))
 
 
     class torch:


### PR DESCRIPTION
This should fix #9 
The warnings can be filtered by using `warnings.simplefilter` like this:
`warnings.simplefilter('default', ImportWarning) # warning will be shown only once`
or 
`warnings.simplefilter('ignore', ImportWarning) # warning will be completely ignored`

cc @jenspetersen 