### PR TITLE
Pin slackclient version in requirements

### DIFF
--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -5,4 +5,4 @@ python-telegram-bot>=10.1.0
 umap-learn>=0.3.6
 scikit-learn>=0.19.1
 opencv-python==3.3.0.10
-slackclient>=1.3.0
+slackclient==1.3.1


### PR DESCRIPTION
Due to an API change in slackclient>=2.0, the PytorchExperimentLogger cannot be
imported. Until the trixi API is updated use a working slackclient version.

Related issue #16

Signed-off-by: Giorgos Paraskevopoulos <geopar@central.ntua.gr>